### PR TITLE
copy over failing deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,230 +1,274 @@
-name: Deploy
-on:
-  workflow_dispatch:
-    inputs:
-      env:
-        description: 'Deploy to (dev|prod|dev prod)'
-        required: true
-        default: 'dev'
-      clean:
-        description: 'Clean cache (yes|no)'
-        required: true
-        default: 'no'
-      excludeSubfolder:
-        description: 'Exclude a subfolder from deletion'
-        required: false
-        default: ''
-jobs:
-  set-state:
-    runs-on: ubuntu-latest
-    outputs:
-      deploy_prod: ${{ contains(github.event.inputs.env, 'prod') }}
-      deploy_dev: ${{ contains(github.event.inputs.env, 'dev') }}
-      clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}
-      path_prefix: ${{ steps.extract_path_prefix.outputs.path_prefix }}
-      branch_short_ref: ${{ steps.extract_branch.outputs.branch }}
-      exclude_subfolder: ${{ github.event.inputs.excludeSubfolder }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
-        with:
-          persist-credentials: false
-      - name: Extract path prefix
-        uses: actions/github-script@v3
-        id: extract_path_prefix
-        with:
-          script: |
-            const {pathPrefix} = require(`${process.env.GITHUB_WORKSPACE}/gatsby-config.js`)
-            if (!pathPrefix) {
-              core.setFailed('Missing path prefix')
-            }
-            else if (pathPrefix === '/') {
-              core.setFailed('Path prefix "/" is not allowed')
-            }
-            else if (!pathPrefix.startsWith('/') || !pathPrefix.endsWith('/')) {
-              core.setFailed('Path prefix should start and end with "/"')
-            }
-            core.setOutput('path_prefix', pathPrefix)
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
-
-  echo-state:
-    needs: [set-state]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Deploy to dev - ${{ needs.set-state.outputs.deploy_dev }}"
-      - run: echo "Deploy to prod - ${{ needs.set-state.outputs.deploy_prod }}"
-      - run: echo "Clean cache - ${{ needs.set-state.outputs.clean_cache }}"
-      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
-      - run: echo "Repository name - ${{ github.event.repository.name }}"
-      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
-      - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
-      - run: echo "Exclude subfolder - ${{ needs.set-state.outputs.exclude_subfolder }}"
-
-  pre-build-dev:
-    needs: [set-state]
-    runs-on: ubuntu-latest
-    if: needs.set-state.outputs.deploy_dev == 'true'
-    steps:
-      - name: check dev azure connection string
-        if: env.AIO_AZURE_DEV_CONNECTION_STRING == null
-        run: |
-          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_DEV_CONNECTION_STRING in Github Secrets"
-          exit 1
+---
+  name: Deployment
+  on:
+    workflow_dispatch:
+      inputs:
         env:
-          AIO_AZURE_DEV_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
-
-  build-dev:
-    defaults:
-      run:
-        shell: bash
-    needs: [set-state, pre-build-dev]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
-        with:
-          persist-credentials: false
-      - name: NPM Install
-        uses: bahmutov/npm-install@v1
-      - name: Gatsby Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            public
-            .cache
-          key: ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-${{ github.run_id }}
-          restore-keys: |
-            ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-
-      - name: Clean Cache
-        if: needs.set-state.outputs.clean_cache == 'true'
-        run: |
-          npm run clean
-      - name: Build
-        run: |
-          npm run build
-        env:
-          PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
-          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
-          GATSBY_ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_DEV_SRC }}
-          GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS: ${{ secrets.AIO_REPORT_SUITE_DEV}}
-          GATSBY_ADOBE_ANALYTICS_ENV: 'dev'
-          REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_OWNER: ${{ github.event.repository.owner.login }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
-          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-          GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
-          GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
-          GATSBY_IMS_SRC: ${{ secrets.AIO_IMS_PROD_SRC  }}
-          GATSBY_IMS_CONFIG: ${{ secrets.AIO_IMS_DEV_CONFIG }}
-          GATSBY_ALGOLIA_APP_ID: ${{ secrets.AIO_ALGOLIA_APP_ID }}
-          GATSBY_ALGOLIA_API_KEY: ${{ secrets.AIO_ALGOLIA_API_KEY }}
-          GATSBY_ALGOLIA_INDEX_ALL_SRC: ${{ secrets.AIO_ALGOLIA_INDEX_ALL_SRC }}
-          GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
-          GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
-          GATSBY_REDOCLY_KEY : ${{ secrets.REDOCLY_LICENSE_KEY }}
-      - name: Deploy
-        uses: AdobeDocs/static-website-deploy@master
-        with:
-          enabled-static-website: 'true'
-          source: 'public'
-          target: ${{ needs.set-state.outputs.path_prefix }}
-          connection-string: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
-          remove-existing-files: 'true'
-          exclude-subfolder: ${{ needs.set-state.outputs.exclude_subfolder }}
-      - name: Delay purge
-        run: sleep 60s
-        shell: bash
-      - name: Purge Fastly Cache
-        uses: AdobeDocs/gatsby-fastly-purge-action@master
-        with:
-          fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
-          fastly-url: '${{ secrets.AIO_FASTLY_DEV_URL}}${{ needs.set-state.outputs.path_prefix }}'
-
-  pre-build-production:
-    needs: [set-state]
-    runs-on: ubuntu-latest
-    if: needs.set-state.outputs.deploy_prod == 'true'
-    steps:
-      - name: check prod azure connection string
-        if: env.AIO_AZURE_PROD_CONNECTION_STRING == null
-        run: |
-          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_PROD_CONNECTION_STRING in Github Secrets"
-          exit 1
-        env:
-          AIO_AZURE_PROD_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
-
-  build-production:
-    defaults:
-      run:
-        shell: bash
-    needs: [set-state, pre-build-production]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
-        with:
-          persist-credentials: false
-      - name: NPM Install
-        uses: bahmutov/npm-install@v1
-      - name: Gatsby Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            public
-            .cache
-          key: ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-${{ github.run_id }}
-          restore-keys: |
-            ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-
-      - name: Clean Cache
-        if: needs.set-state.outputs.clean_cache == 'true'
-        run: |
-          npm run clean
-      - name: Build
-        run: |
-          npm run build
-        env:
-          PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
-          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
-          GATSBY_ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_PROD_SRC }}
-          GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS: ${{ secrets.AIO_REPORT_SUITE_PROD }}
-          GATSBY_ADOBE_ANALYTICS_ENV: 'production'
-          REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_OWNER: ${{ github.event.repository.owner.login }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
-          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-          GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
-          GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
-          GATSBY_IMS_SRC: ${{ secrets.AIO_IMS_PROD_SRC }}
-          GATSBY_IMS_CONFIG: ${{ secrets.AIO_IMS_PROD_CONFIG }}
-          ALGOLIA_WRITE_API_KEY: ${{ secrets.AIO_ALGOLIA_WRITE_API_KEY }}
-          ALGOLIA_INDEXATION_MODE: ${{ secrets.AIO_ALGOLIA_INDEXATION_MODE }}
-          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME || github.event.repository.name }}
-          GATSBY_ALGOLIA_APP_ID: ${{ secrets.AIO_ALGOLIA_APP_ID }}
-          GATSBY_ALGOLIA_API_KEY: ${{ secrets.AIO_ALGOLIA_API_KEY }}
-          GATSBY_ALGOLIA_INDEX_ALL_SRC: ${{ secrets.AIO_ALGOLIA_INDEX_ALL_SRC }}
-          GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
-          GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
-      - name: Deploy
-        uses: AdobeDocs/static-website-deploy@master
-        with:
-          enabled-static-website: 'true'
-          source: 'public'
-          target: ${{ needs.set-state.outputs.path_prefix }}
-          connection-string: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
-          remove-existing-files: 'true'
-          exclude-subfolder: ${{ needs.set-state.outputs.exclude_subfolder }}
-      - name: Delay purge
-        run: sleep 60s
-        shell: bash
-      - name: Purge Fastly Cache
-        uses: AdobeDocs/gatsby-fastly-purge-action@master
-        with:
-          fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
-          fastly-url: '${{ secrets.AIO_FASTLY_PROD_URL }}${{ needs.set-state.outputs.path_prefix }}'
+          description: "Deploy to (dev|prod|dev prod)"
+          required: true
+          default: "dev"
+        clean:
+          description: "Clean cache (yes|no)"
+          required: true
+          default: "no"
+        excludeSubfolder:
+          description: "Exclude a subfolder from deletion"
+          required: false
+          default: ""
+        index-mode:
+          description: 'Type of indexing. "index" to push to Algolia, "console" for dry run.'
+          required: true
+          default: "index"
+          type: choice
+          options:
+            - console
+            - index
+  jobs:
+    set-state:
+      runs-on: ubuntu-latest
+      outputs:
+        deploy_prod: ${{ contains(github.event.inputs.env, 'prod') }}
+        deploy_dev: ${{ contains(github.event.inputs.env, 'dev') }}
+        clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}
+        path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
+        branch_short_ref: ${{ steps.get_branch.outputs.branch }}
+        exclude_subfolder: ${{ github.event.inputs.excludeSubfolder }}
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+  
+        - name: Get pathPrefix
+          uses: actions/github-script@v6
+          id: get_path_prefix
+          with:
+            script: |
+              const script = require('./.github/scripts/get-path-prefix.js');
+              script({ core });
+            result-encoding: string
+        - name: Get branch name
+          shell: bash
+          run: echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+          id: get_branch
+  
+    echo-state:
+      needs: [set-state]
+      runs-on: ubuntu-latest
+      steps:
+        - run: echo "Deploy to dev - ${{ needs.set-state.outputs.deploy_dev }}"
+        - run: echo "Deploy to prod - ${{ needs.set-state.outputs.deploy_prod }}"
+        - run: echo "Clean cache - ${{ needs.set-state.outputs.clean_cache }}"
+        - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
+        - run: echo "Repository name - ${{ github.event.repository.name }}"
+        - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
+        - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
+        - run: echo "Exclude subfolder - ${{ needs.set-state.outputs.exclude_subfolder }}"
+  
+    pre-build-dev:
+      needs: [set-state]
+      runs-on: ubuntu-latest
+      if: needs.set-state.outputs.deploy_dev == 'true'
+      steps:
+        - name: check dev azure connection string
+          if: env.AIO_AZURE_DEV_CONNECTION_STRING == null
+          run: |
+            echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_DEV_CONNECTION_STRING in Github Secrets"
+            exit 1
+          env:
+            AIO_AZURE_DEV_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
+  
+    build-dev:
+      defaults:
+        run:
+          shell: bash
+      needs: [set-state, pre-build-dev]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+  
+        - name: Setup Node v20 for Yarn v3
+          uses: actions/setup-node@v3
+          with:
+            node-version: "20.19.5" # Current LTS version
+  
+        - name: Enable Corepack for Yarn v3
+          run: corepack enable
+  
+        - name: Install Yarn v3
+          uses: borales/actions-yarn@v3
+          with:
+            cmd: set version stable
+  
+        - name: Install Dependencies
+          uses: borales/actions-yarn@v3
+          env:
+            YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          with:
+            cmd: install
+  
+        - name: Gatsby Cache
+          uses: actions/cache@v3
+          with:
+            path: |
+              public
+              .cache
+            key: ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-${{ github.run_id }}
+            restore-keys: |
+              ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-
+  
+        - name: Clean Cache
+          if: needs.set-state.outputs.clean_cache == 'true'
+          uses: borales/actions-yarn@v3
+          with:
+            cmd: clean
+  
+        - name: Build site
+          uses: borales/actions-yarn@v3
+          with:
+            cmd: build
+          env:
+            PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
+            PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
+            GATSBY_ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_DEV_SRC }}
+            GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS: ${{ secrets.AIO_REPORT_SUITE_DEV}}
+            GATSBY_ADOBE_ANALYTICS_ENV: "dev"
+            REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            REPO_OWNER: ${{ github.event.repository.owner.login }}
+            REPO_NAME: ${{ github.event.repository.name }}
+            REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
+            GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+            GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+            GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
+            GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
+            GATSBY_IMS_SRC: ${{ secrets.AIO_IMS_DEV_SRC }}
+            GATSBY_IMS_CONFIG: ${{ secrets.AIO_IMS_DEV_CONFIG }}
+            GATSBY_ALGOLIA_APPLICATION_ID: ${{ secrets.AIO_ALGOLIA_APPLICATION_ID }}
+            GATSBY_ALGOLIA_SEARCH_API_KEY: ${{ secrets.AIO_ALGOLIA_SEARCH_API_KEY }}
+            GATSBY_ALGOLIA_APP_ID: ${{ secrets.AIO_ALGOLIA_APP_ID }}
+            GATSBY_ALGOLIA_API_KEY: ${{ secrets.AIO_ALGOLIA_API_KEY }}
+            GATSBY_ALGOLIA_INDEX_ALL_SRC: ${{ secrets.AIO_ALGOLIA_INDEX_ALL_SRC }}
+            GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
+            GATSBY_ALGOLIA_INDEX_ENV_PREFIX: ${{ secrets.AIO_ALGOLIA_INDEX_ENV_PREFIX }}
+            GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
+            GATSBY_SITE_DOMAIN_URL: https://developer-stage.adobe.com
+  
+        - name: Deploy
+          uses: AdobeDocs/static-website-deploy@master
+          with:
+            enabled-static-website: "true"
+            source: "public"
+            target: ${{ needs.set-state.outputs.path_prefix }}
+            connection-string: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
+            remove-existing-files: "true"
+            exclude-subfolder: ${{ needs.set-state.outputs.exclude_subfolder }}
+        - name: Purge Fastly Cache
+          uses: AdobeDocs/gatsby-fastly-purge-action@master
+          with:
+            fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
+            fastly-url: "${{ secrets.AIO_FASTLY_DEV_URL}}${{ needs.set-state.outputs.path_prefix }}"
+  
+    pre-build-production:
+      needs: [set-state]
+      runs-on: ubuntu-latest
+      if: needs.set-state.outputs.deploy_prod == 'true'
+      steps:
+        - name: check prod azure connection string
+          if: env.AIO_AZURE_PROD_CONNECTION_STRING == null
+          run: |
+            echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_PROD_CONNECTION_STRING in Github Secrets"
+            exit 1
+          env:
+            AIO_AZURE_PROD_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
+  
+    build-production:
+      defaults:
+        run:
+          shell: bash
+      needs: [set-state, pre-build-production]
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+  
+        - name: Setup Node v20 for Yarn v3
+          uses: actions/setup-node@v3
+          with:
+            node-version: "20.19.5" # Current LTS version
+  
+        - name: Enable Corepack for Yarn v3
+          run: corepack enable
+  
+        - name: Install Yarn v3
+          uses: borales/actions-yarn@v3
+          with:
+            cmd: set version stable
+  
+        - name: Install Dependencies
+          uses: borales/actions-yarn@v3
+          env:
+            YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          with:
+            cmd: install
+  
+        - name: Gatsby Cache
+          uses: actions/cache@v3
+          with:
+            path: |
+              public
+              .cache
+            key: ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-${{ github.run_id }}
+            restore-keys: |
+              ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-
+  
+        - name: Clean Cache
+          if: needs.set-state.outputs.clean_cache == 'true'
+          uses: borales/actions-yarn@v3
+          with:
+            cmd: clean
+  
+        - name: Build site
+          uses: borales/actions-yarn@v3
+          with:
+            cmd: build
+          env:
+            PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
+            PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
+            GATSBY_ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_PROD_SRC }}
+            GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS: ${{ secrets.AIO_REPORT_SUITE_PROD }}
+            GATSBY_ADOBE_ANALYTICS_ENV: "production"
+            REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            REPO_OWNER: ${{ github.event.repository.owner.login }}
+            REPO_NAME: ${{ github.event.repository.name }}
+            REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
+            GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+            GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+            GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
+            GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
+            GATSBY_IMS_SRC: ${{ secrets.AIO_IMS_PROD_SRC }}
+            GATSBY_IMS_CONFIG: ${{ secrets.AIO_IMS_PROD_CONFIG }}
+            GATSBY_ALGOLIA_APPLICATION_ID: ${{ secrets.AIO_ALGOLIA_APPLICATION_ID }}
+            GATSBY_ALGOLIA_SEARCH_API_KEY: ${{ secrets.AIO_ALGOLIA_SEARCH_API_KEY }}
+            GATSBY_ALGOLIA_APP_ID: ${{ secrets.AIO_ALGOLIA_APP_ID }}
+            GATSBY_ALGOLIA_API_KEY: ${{ secrets.AIO_ALGOLIA_API_KEY }}
+            ALGOLIA_WRITE_API_KEY: ${{ secrets.AIO_ALGOLIA_WRITE_API_KEY }}
+            ALGOLIA_INDEXATION_MODE: ${{ github.event.inputs.index-mode || 'index' }}
+            GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME || github.event.repository.name }}
+            GATSBY_ALGOLIA_INDEX_ALL_SRC: ${{ secrets.AIO_ALGOLIA_INDEX_ALL_SRC }}
+            GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
+            GATSBY_ALGOLIA_INDEX_ENV_PREFIX: ${{ secrets.AIO_ALGOLIA_INDEX_ENV_PREFIX }}
+            GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
+            GATSBY_SITE_DOMAIN_URL: https://developer.adobe.com
+        - name: Deploy
+          uses: AdobeDocs/static-website-deploy@master
+          with:
+            enabled-static-website: "true"
+            source: "public"
+            target: ${{ needs.set-state.outputs.path_prefix }}
+            connection-string: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
+            remove-existing-files: "true"
+            exclude-subfolder: ${{ needs.set-state.outputs.exclude_subfolder }}
+        - name: Purge Fastly Cache
+          uses: AdobeDocs/gatsby-fastly-purge-action@master
+          with:
+            fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
+            fastly-url: "${{ secrets.AIO_FASTLY_PROD_URL }}${{ needs.set-state.outputs.path_prefix }}"


### PR DESCRIPTION
Copy over failing `deploy.yml` so we can use this repo as a testing ground (and not clutter client repos with test commits and test deploys) while investigating the following error affecting a lot of gatsby repos today:
```
error "internal-data-bridge" threw an error while running the sourceNodes lifecycle:
"length" is outside of buffer bounds
RangeError:"length" is outside of buffer bound
```

| Repo | Deploy | Thread |
| -- | -- | -- |
| aem-developer-materials | https://github.com/AdobeDocs/aem-developer-materials/actions/runs/18911223974/job/53982318388 | https://adobeio.slack.com/archives/C01GU3V8XE0/p1761751757939859 |
| uxp-premier-pro | https://github.com/AdobeDocs/uxp-premiere-pro/actions/runs/18911315314/job/53982597791 | https://adobeio.slack.com/archives/GTSGK6807/p1761749899044149 |
| create-embed-sdk | https://github.com/AdobeDocs/create-embed-sdk/actions/runs/18913418739/job/53990226428 | https://adobeio.slack.com/archives/C06M1C7UBV3/p1761752268663609 |

Team discussion: https://adobeio.slack.com/archives/C06M1C7UBV3/p1761752410760889
