### PR TITLE
test: pin yarn version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,7 @@
         - name: Install Yarn v3
           uses: borales/actions-yarn@v3
           with:
-            cmd: set version stable
+            cmd: set version 3.2.1
   
         - name: Install Dependencies
           uses: borales/actions-yarn@v3


### PR DESCRIPTION
Running `yarn build` locally succeeds:
<img width="568" height="651" alt="Screenshot 2025-10-29 at 2 57 55 PM" src="https://github.com/user-attachments/assets/a72f88c8-8f87-4f7f-a649-f986e15e4f77" />


but building on deploy (via GitHub actions) fails:
<img width="1193" height="910" alt="Screenshot 2025-10-29 at 2 58 43 PM" src="https://github.com/user-attachments/assets/2af560f6-6141-4da4-aef6-e5dd9d0ae88d" />


Pinning yarn version to ensure GitHub uses exact same yarn version as [local](https://github.com/AdobeDocs/redocly-test/blob/main/package.json#L34).